### PR TITLE
added optional CFBundleShortVersionString

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -24,10 +24,16 @@ fi
 
 CONFIG_project_info_plist_path="${plist_path}"
 CONFIG_new_bundle_version="${build_version}"
+CONFIG_new_short_bundle_short_version_string="${build_short_version_string}"
 
 echo " (i) Provided Info.plist path: ${CONFIG_project_info_plist_path}"
 echo " (i) Build number (bundle version): ${CONFIG_new_bundle_version}"
 
+if [ -n "${CONFIG_new_short_bundle_short_version_string}" ] ; then
+  echo " (i) Build number (bundle short version string): ${CONFIG_new_short_bundle_short_version_string}"
+else
+  echo " (i) Build number (bundle short version string): Not specified"
+fi
 
 # ---------------------
 # --- Main:
@@ -41,4 +47,11 @@ set -v
 # ---- Set Bundle Version:
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${CONFIG_new_bundle_version}" "${CONFIG_project_info_plist_path}"
 
-# ==> Bundle Version / Build Number changed
+if [ -n "${CONFIG_new_short_bundle_short_version_string}" ] ; then
+  # ---- Current Bundle Short Version String:
+  /usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${CONFIG_project_info_plist_path}"
+
+  # ---- Set Bundle Short Version String:
+  /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CONFIG_new_short_bundle_short_version_string}" "${CONFIG_project_info_plist_path}"
+fi
+# ==> Bundle Version and Short Version changed

--- a/step.yml
+++ b/step.yml
@@ -34,7 +34,14 @@ inputs:
   - build_version: "$BITRISE_BUILD_NUMBER"
     opts:
       title: "Build Number"
-      summary: "Set the Build Number / Bundle Version to this value."
+      summary: "Set the CFBundleVersion to this value."
       is_required: true
+      is_expand: true
+      is_dont_change_value: false
+  - build_short_version_string: 
+    opts: 
+      title: "Build Number String"
+      summary: "(Optional) Set the CFBundleShortVersionString to this value."
+      is_required: false
       is_expand: true
       is_dont_change_value: false


### PR DESCRIPTION
Hi,

I would like to add the option to modify the string version name in the build step.

I am not sure whether I should be doing a PR to this repo, or straight to the steplib repo. The command "bitrise share" tells me to PR into the steplib repo, but this is not my own step.

Thanks for the guidance!
