### PR TITLE
Use step.deps instead of step.dependencies

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -14,9 +14,9 @@ project_type_tags:
 type_tags:
   - build
   - xcode
-dependencies:
-  - manager: _
-    name: xcode
+deps:
+  check_only:
+  - name: xcode
 run_if: ".IsCI"
 inputs:
   - plist_path:


### PR DESCRIPTION
- Solves the following warning "WARN step.dependencies is
  deprecated... Use step.deps instead."
