### PR TITLE
fix: change BuildVersion to int64 allowing larger build numbers

### DIFF
--- a/step/models.go
+++ b/step/models.go
@@ -5,8 +5,8 @@ type Input struct {
 	Scheme                  string `env:"scheme,required"`
 	Target                  string `env:"target"`
 	Configuration           string `env:"configuration"`
-	BuildVersion            int    `env:"build_version,required"`
-	BuildVersionOffset      int    `env:"build_version_offset"`
+	BuildVersion            int64  `env:"build_version,required"`
+	BuildVersionOffset      int64  `env:"build_version_offset"`
 	BuildShortVersionString string `env:"build_short_version_string"`
 }
 
@@ -15,11 +15,11 @@ type Config struct {
 	Scheme                  string
 	Target                  string
 	Configuration           string
-	BuildVersion            int
-	BuildVersionOffset      int
+	BuildVersion            int64
+	BuildVersionOffset      int64
 	BuildShortVersionString string
 }
 
 type Result struct {
-	BuildVersion int
+	BuildVersion int64
 }

--- a/step/step.go
+++ b/step/step.go
@@ -79,7 +79,7 @@ func (u Updater) Run(config Config) (Result, error) {
 }
 
 func (u Updater) Export(result Result) error {
-	return u.exporter.ExportOutput("XCODE_BUNDLE_VERSION", strconv.Itoa(result.BuildVersion))
+	return u.exporter.ExportOutput("XCODE_BUNDLE_VERSION", strconv.FormatInt(result.BuildVersion, 10))
 }
 
 func generatesInfoPlist(helper *projectmanager.ProjectHelper, targetName, configuration string) (bool, error) {
@@ -93,7 +93,7 @@ func generatesInfoPlist(helper *projectmanager.ProjectHelper, targetName, config
 	return generatesInfoPlist, err
 }
 
-func updateVersionNumbersInProject(helper *projectmanager.ProjectHelper, targetName, configuration string, bundleVersion int, shortVersion string) error {
+func updateVersionNumbersInProject(helper *projectmanager.ProjectHelper, targetName, configuration string, bundleVersion int64, shortVersion string) error {
 	if targetName == "" {
 		targetName = helper.MainTarget.Name
 	}
@@ -124,7 +124,7 @@ func updateVersionNumbersInProject(helper *projectmanager.ProjectHelper, targetN
 	return nil
 }
 
-func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, targetName, configuration string, bundleVersion int, shortVersion string) error {
+func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, targetName, configuration string, bundleVersion int64, shortVersion string) error {
 	buildConfig, err := buildConfiguration(helper, targetName, configuration)
 	if err != nil {
 		return err

--- a/step/step.go
+++ b/step/step.go
@@ -138,7 +138,7 @@ func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, targe
 	absoluteInfoPlistPath := filepath.Join(filepath.Dir(helper.XcProj.Path), infoPlistPath)
 
 	infoPlist, format, _ := xcodeproj.ReadPlistFile(absoluteInfoPlistPath)
-	infoPlist["CFBundleVersion"] = strconv.Itoa(bundleVersion)
+	infoPlist["CFBundleVersion"] = strconv.FormatInt(bundleVersion, 10)
 
 	if shortVersion != "" {
 		infoPlist["CFBundleShortVersionString"] = shortVersion

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -17,7 +17,7 @@ func TestExport(t *testing.T) {
 	result := Result{BuildVersion: 999}
 
 	mockFactory := mocks.NewFactory(t)
-	arguments := []string{"add", "--key", "XCODE_BUNDLE_VERSION", "--value", strconv.Itoa(result.BuildVersion)}
+	arguments := []string{"add", "--key", "XCODE_BUNDLE_VERSION", "--value", strconv.FormatInt(result.BuildVersion, 10)}
 	mockFactory.On("Create", "envman", arguments, (*command.Opts)(nil)).Return(testCommand())
 
 	inputParser := stepconf.NewInputParser(env.NewRepository())


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a patch version.

### Context

Changes `build_version` to an int64, allowing larger numbers to be used as the build number.

https://github.com/bitrise-steplib/steps-set-xcode-build-number/issues/36


### Changes

BuildVersion is now int64 (instead of an int)

### Investigation details

This was not an issue on previous versions, our builds started failing once 2.0 was released. Might be others affected that use similar format for their builds
