### PR TITLE
[CI-2849] Resolve env vars with xcodebuild

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -77,7 +77,7 @@ func (u Updater) Run(config Config) (Result, error) {
 	} else {
 		u.logger.Printf("The version numbers are stored in the plist file.")
 
-		err := updateVersionNumbersInInfoPlist(helper, config.Scheme, config.Target, config.Configuration, buildVersion, config.BuildShortVersionString)
+		err := u.updateVersionNumbersInInfoPlist(helper, config.Scheme, config.Target, config.Configuration, buildVersion, config.BuildShortVersionString)
 		if err != nil {
 			return Result{}, err
 		}
@@ -134,7 +134,7 @@ func updateVersionNumbersInProject(helper *projectmanager.ProjectHelper, targetN
 	return nil
 }
 
-func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, schemeName, targetName, configuration string, bundleVersion int64, shortVersion string) error {
+func (u Updater) updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, schemeName, targetName, configuration string, bundleVersion int64, shortVersion string) error {
 	buildConfig, err := buildConfiguration(helper, targetName, configuration)
 	if err != nil {
 		return err
@@ -155,6 +155,9 @@ func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, schem
 	// will define this env var, so we only know its value during an xcodebuild execution. So if we see an env var in
 	// the path, then we have to list the build settings with `xcodebuild -showBuildSettings` to get a valid path value.
 	if hasEnvVars(infoPlistPath) {
+		u.logger.Printf("Info.plist path contains env var: %s\n", infoPlistPath)
+		u.logger.Printf("Using xcodebuild to resolve it\n")
+
 		infoPlistPath, err = extractInfoPlistPathWithXcodebuild(helper.XcProj.Path, schemeName, targetName, configuration)
 		if err != nil {
 			return err

--- a/step/step.go
+++ b/step/step.go
@@ -3,13 +3,23 @@ package step
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/bitrise-io/go-steputils/v2/export"
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
+	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager"
 	"github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj"
+)
+
+const (
+	infoPlistFileKey = "INFOPLIST_FILE"
+	envVarRegex      = `^.*\$\(.+\).*$`
 )
 
 type Updater struct {
@@ -67,7 +77,7 @@ func (u Updater) Run(config Config) (Result, error) {
 	} else {
 		u.logger.Printf("The version numbers are stored in the plist file.")
 
-		err := updateVersionNumbersInInfoPlist(helper, config.Target, config.Configuration, buildVersion, config.BuildShortVersionString)
+		err := updateVersionNumbersInInfoPlist(helper, config.Scheme, config.Target, config.Configuration, buildVersion, config.BuildShortVersionString)
 		if err != nil {
 			return Result{}, err
 		}
@@ -124,32 +134,103 @@ func updateVersionNumbersInProject(helper *projectmanager.ProjectHelper, targetN
 	return nil
 }
 
-func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, targetName, configuration string, bundleVersion int64, shortVersion string) error {
+func updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectHelper, schemeName, targetName, configuration string, bundleVersion int64, shortVersion string) error {
 	buildConfig, err := buildConfiguration(helper, targetName, configuration)
 	if err != nil {
 		return err
 	}
 
-	infoPlistPath, err := buildConfig.BuildSettings.String("INFOPLIST_FILE")
+	infoPlistPath, err := buildConfig.BuildSettings.String(infoPlistFileKey)
 	if err != nil {
 		return err
 	}
 
-	absoluteInfoPlistPath := filepath.Join(filepath.Dir(helper.XcProj.Path), infoPlistPath)
+	// By default, the setting for the Info.plist file path is a relative path from the project file. Of course,
+	// developers can override this with something more custom to their setup. They can also use Xcode env vars as part
+	// of their path.
+	//
+	// An example from a SWAT ticket: `$(SRCROOT)/path/to/Info.plist`.
+	//
+	// The problem with this is that it is not a real path until the env var is resolved. And in this case, Xcode
+	// will define this env var, so we only know its value during an xcodebuild execution. So if we see an env var in
+	// the path, then we have to list the build settings with `xcodebuild -showBuildSettings` to get a valid path value.
+	if hasEnvVars(infoPlistPath) {
+		infoPlistPath, err = extractInfoPlistPathWithXcodebuild(helper.XcProj.Path, schemeName, targetName, configuration)
+		if err != nil {
+			return err
+		}
+	}
 
-	infoPlist, format, _ := xcodeproj.ReadPlistFile(absoluteInfoPlistPath)
+	if pathutil.IsRelativePath(infoPlistPath) {
+		infoPlistPath = filepath.Join(filepath.Dir(helper.XcProj.Path), infoPlistPath)
+	}
+
+	infoPlist, format, _ := xcodeproj.ReadPlistFile(infoPlistPath)
 	infoPlist["CFBundleVersion"] = strconv.FormatInt(bundleVersion, 10)
 
 	if shortVersion != "" {
 		infoPlist["CFBundleShortVersionString"] = shortVersion
 	}
 
-	err = xcodeproj.WritePlistFile(absoluteInfoPlistPath, infoPlist, format)
+	err = xcodeproj.WritePlistFile(infoPlistPath, infoPlist, format)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func hasEnvVars(path string) bool {
+	re := regexp.MustCompile(envVarRegex)
+	containsEnvVar := re.Match([]byte(path))
+
+	return containsEnvVar
+}
+
+func extractInfoPlistPathWithXcodebuild(projectPath, scheme, target, configuration string) (string, error) {
+	args := []string{"-project", projectPath, "-scheme", scheme}
+
+	if target != "" {
+		args = append(args, "-target", target)
+	}
+
+	if configuration != "" {
+		args = append(args, "-configuration", configuration)
+	}
+
+	args = append(args, "-showBuildSettings")
+
+	cmd := command.NewFactory(env.NewRepository()).Create("xcodebuild", args, nil)
+	output, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	path := infoPlistPathFromOutput(output)
+	if path == "" {
+		return "", fmt.Errorf("missing Info.plist file path")
+	}
+
+	return path, nil
+}
+
+func infoPlistPathFromOutput(output string) string {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		split := strings.Split(line, " = ")
+
+		if len(split) < 2 {
+			continue
+		}
+
+		if strings.TrimSpace(split[0]) != infoPlistFileKey {
+			continue
+		}
+
+		return strings.TrimSpace(split[1])
+	}
+
+	return ""
 }
 
 func buildConfiguration(helper *projectmanager.ProjectHelper, targetName, configuration string) (*xcodeproj.BuildConfiguration, error) {

--- a/testdata/project/Example/Example.xcodeproj/project.pbxproj
+++ b/testdata/project/Example/Example.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = KUN9FDAF5L;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Example/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -527,7 +527,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = KUN9FDAF5L;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Example/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

When you create a new project the default setting for the Info.plist file in your build settings is a relative path from the project file. But this can be freely overridden by the user and for example we could have something like this there:
```
$(SRCROOT)/path/to/Info.plist
```
A value with an embedded env var which can be only resolved by Xcode. This is just one example as there are multiple Xcode env vars. The step needs to handle these cases as well.

The simplest solution is to check if the returned value contains an env var. If it does then use `xcodebuild -showBuildSettings` to list all of the build settings. When we are doing this then Xcode will resolve all of the env vars. 

I need to mention that this will be a fallback mechanism because this `xcodebuild` command can take a lot of time for larger projects. 

I have updated one of the e2e test projects to have it's Info.plist path defined with an env var.