### PR TITLE
[CI-2872] Add more logging

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -66,6 +66,7 @@ workflows:
         - build_version: 9994
         - build_version_offset: 5
         - build_short_version_string: 9.99.9
+        - verbose: "true"
     - script:
         title: Build app
         inputs:

--- a/step.yml
+++ b/step.yml
@@ -112,6 +112,16 @@ inputs:
 
       If it is empty then the step will not modify the existing value.
 
+- verbose: "false"
+  opts:
+    category: Debug
+    title: Enable verbose logging
+    summary: Enable logging additional information for debugging.
+    is_required: true
+    value_options:
+    - "true"
+    - "false"
+
 outputs:
 - XCODE_BUNDLE_VERSION:
   opts:

--- a/step/models.go
+++ b/step/models.go
@@ -8,6 +8,7 @@ type Input struct {
 	BuildVersion            int64  `env:"build_version,required"`
 	BuildVersionOffset      int64  `env:"build_version_offset"`
 	BuildShortVersionString string `env:"build_short_version_string"`
+	Verbose                 bool   `env:"verbose,required"`
 }
 
 type Config struct {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

There was a recent SWAT ticket where this step worked differently than the customers bash script. Upon further investigation I think the step was configured differently that the bash script and that caused the version numbers not being updated. 

I have included some extra logs to help debug future issues.

### Changes

There is a new verbose input which will make the step print more useful logs for debugging. The new debug logs will look like this:
```
Updating build settings for the Example target
CURRENT_PROJECT_VERSION 1 -> 9999
MARKETING_VERSION 1.0 -> 9.99.9
```
and
```
Updating Info.plist at /Users/szabi/Dev/bitrise-steplib/steps-set-xcode-build-number/testdata/project/Example/Example/Example-Static-Info.plist
CFBundleVersion 19876 -> 9999
CFBundleShortVersionString 12.5.5 -> 9.99.9
```
So it will print out which target or info.plist path is being updated and also it will print the old values too.