### PR TITLE
Handle plist opening errors

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -187,7 +187,11 @@ func (u Updater) updateVersionNumbersInInfoPlist(helper *projectmanager.ProjectH
 
 	u.logger.Printf("Updating Info.plist at %s", infoPlistPath)
 
-	infoPlist, format, _ := xcodeproj.ReadPlistFile(infoPlistPath)
+	infoPlist, format, err := xcodeproj.ReadPlistFile(infoPlistPath)
+	if err != nil {
+		return err
+	}
+
 	oldVersion := infoPlist["CFBundleVersion"]
 	newVersion := strconv.FormatInt(bundleVersion, 10)
 	infoPlist["CFBundleVersion"] = newVersion


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

The step does not handle the plist opening/parsing errors and one of the customers ran into it. 

The step is crashing for them because after the calling 
```
xcodeproj.ReadPlistFile(infoPlistPath)
```
the returned map is empty and the step tries to insert a value in an uninitialised map. 

The only way for that function call to return a nil map is if it either could not open or parse the file.