### PR TITLE
Empty error fix

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -302,5 +302,5 @@ func buildConfiguration(helper *projectmanager.ProjectHelper, targetName, config
 		}
 	}
 
-	return nil, fmt.Errorf("")
+	return nil, fmt.Errorf("build configuration not found for target '%s' with configuration name '%s'", targetName, configuration)
 }

--- a/step/step.go
+++ b/step/step.go
@@ -290,17 +290,29 @@ func buildConfiguration(helper *projectmanager.ProjectHelper, targetName, config
 		configuration = helper.MainTarget.BuildConfigurationList.DefaultConfigurationName
 	}
 
+	var xcodeprojTarget *xcodeproj.Target
 	for _, target := range helper.XcProj.Proj.Targets {
-		if target.Name != targetName {
-			continue
-		}
-
-		for _, buildConfig := range target.BuildConfigurationList.BuildConfigurations {
-			if buildConfig.Name == configuration {
-				return &buildConfig, nil
-			}
+		if target.Name == targetName {
+			xcodeprojTarget = &target
+			break
 		}
 	}
 
-	return nil, fmt.Errorf("build configuration not found for target '%s' with configuration name '%s'", targetName, configuration)
+	if xcodeprojTarget == nil {
+		return nil, fmt.Errorf("target '%s' not found in project: %s", targetName, helper.XcProj.Path)
+	}
+
+	var xcodeprojBuildConfiguration *xcodeproj.BuildConfiguration
+	for _, buildConfig := range xcodeprojTarget.BuildConfigurationList.BuildConfigurations {
+		if buildConfig.Name == configuration {
+			xcodeprojBuildConfiguration = &buildConfig
+			break
+		}
+	}
+
+	if xcodeprojBuildConfiguration == nil {
+		return nil, fmt.Errorf("build configuration '%s' not found for target '%s' in project: %s", configuration, targetName, helper.XcProj.Path)
+	}
+
+	return xcodeprojBuildConfiguration, nil
 }


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR fixes an issue with the project build configuration search logic, where the related function returned an empty error if no configuration was found.

### Changes

- `buildConfiguration` func returns meaningfully error messages
